### PR TITLE
feat: supply list of id and destination in parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,12 @@ home page retrieves all hotels merged from all the sources already normalized an
 
 retrieves hotels filtered with supplied params
 
-| Params         | Description                 |
-| -------------- | --------------------------- |
-| id             | filters by `id` of hotel    |
-| destination_id | filters by `destination_id` |
+| Params          | Description                 | Example                      |
+| --------------- | --------------------------- | ---------------------------- |
+| ids             | filters by `id` of hotel    | `?ids=f8c9,f8c3`             |
+| destination_ids | filters by `destination_id` | `?destination_ids=123,39383` |
 
-_NOTE_: endpoint only accepts either `id` or `destination_id` at a time. Status `400 - BadRequest` is returned if both are supplied at the same time.
-
-_ASSUMPTION_: multiple hotels can share the same `destination_id`
+_NOTE_: endpoint only accepts either `ids` or `destination_ids` at a time. Status `400 - BadRequest` is returned if both are supplied at the same time.
 
 ## Response
 

--- a/internal/hotels/store.go
+++ b/internal/hotels/store.go
@@ -1,5 +1,11 @@
 package hotels
 
+import (
+	"slices"
+	"strconv"
+	"strings"
+)
+
 type HotelStore struct {
 	hotels Hotels
 }
@@ -16,20 +22,24 @@ func (s *HotelStore) GetAll() Hotels {
 	return s.hotels
 }
 
-func (s *HotelStore) FilterById(id string) Hotels {
+func (s *HotelStore) FilterByIds(ids string) Hotels {
+	idsArr := strings.Split(ids, ",")
+	var result Hotels
+
 	for _, h := range s.hotels {
-		if h.Id == id {
-			return Hotels{h}
+		if slices.Contains(idsArr, strings.TrimSpace(h.Id)) {
+			result = append(result, h)
 		}
 	}
 
-	return Hotels{}
+	return result
 }
 
-func (s *HotelStore) FilterByDestination(destinationId int) Hotels {
+func (s *HotelStore) FilterByDestinations(destinationIds string) Hotels {
+	destinationIdsArr := strings.Split(destinationIds, ",")
 	var result Hotels
 	for _, h := range s.hotels {
-		if h.DestinationId == destinationId {
+		if slices.Contains(destinationIdsArr, strings.TrimSpace(strconv.Itoa(h.DestinationId))) {
 			result = append(result, h)
 		}
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/ptrciafae/hotels-merge/internal/hotels"
 )
@@ -20,28 +19,23 @@ func (h *Handlers) handleQueryHotels(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	var result hotels.Hotels
 
-	id := query.Get("id")
-	destinationId := query.Get("destination_id")
+	ids := query.Get("ids")
+	destinationIds := query.Get("destination_ids")
 
-	if id == "" && destinationId == "" {
+	if ids == "" && destinationIds == "" {
 		h.handleGetAllHotels(w, r)
 		return
 	}
 
-	if id != "" && destinationId != "" {
-		http.Error(w, "Only one query parameter (id or destination_id) can be provided at a time", http.StatusBadRequest)
+	if ids != "" && destinationIds != "" {
+		http.Error(w, "Only one query parameter (ids or destination_ids) can be provided at a time", http.StatusBadRequest)
 		return
 	}
 
-	if id != "" {
-		result = h.store.FilterById(id)
-	} else if destId := query.Get("destination_id"); destId != "" {
-		destIdInt, err := strconv.Atoi(destId)
-		if err != nil {
-			http.Error(w, "Invalid destination_id", http.StatusBadRequest)
-			return
-		}
-		result = h.store.FilterByDestination(destIdInt)
+	if ids != "" {
+		result = h.store.FilterByIds(ids)
+	} else if destinationIds := query.Get("destination_ids"); destinationIds != "" {
+		result = h.store.FilterByDestinations(destinationIds)
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
# Description
Overlooked that the [problem statement](https://gist.github.com/Attila24/ab7133f86f7fc83de7996877d92ba88b) mentions a list as parameter 💀 
 
# Decisions

# Before
`/hotels?id={onevalue}` and `/hotels?destination_id?={alsoonevalue}`

# After
`/hotels?ids={onevalue},{secondvalue}` and `/hotels?destination_ids?={alsoonevalue},{secondvalue}`
